### PR TITLE
Add %admin% placeholder to SLOG_COMMAND

### DIFF
--- a/src/main/java/it/frafol/cleanss/bungee/objects/Utils.java
+++ b/src/main/java/it/frafol/cleanss/bungee/objects/Utils.java
@@ -382,7 +382,11 @@ public class Utils {
             return;
         }
 
-        instance.getProxy().getPluginManager().dispatchCommand(instance.getProxy().getConsole(), BungeeConfig.SLOG_COMMAND.get(String.class).replace("%player%", suspicious));
+        instance.getProxy().getPluginManager().dispatchCommand(
+                instance.getProxy().getConsole(),
+                BungeeConfig.SLOG_COMMAND.get(String.class)
+                        .replace("%player%", suspicious)
+                        .replace("%admin%", administrator_player.getName()));
     }
 
     public boolean isInControlServer(ServerInfo server) {

--- a/src/main/java/it/frafol/cleanss/velocity/objects/Utils.java
+++ b/src/main/java/it/frafol/cleanss/velocity/objects/Utils.java
@@ -163,7 +163,11 @@ public class Utils {
             return;
         }
 
-        instance.getServer().getCommandManager().executeAsync(instance.getServer().getConsoleCommandSource(), VelocityConfig.SLOG_COMMAND.get(String.class).replace("%player%", suspicious));
+        instance.getServer().getCommandManager().executeAsync(
+                instance.getServer().getConsoleCommandSource(), 
+                VelocityConfig.SLOG_COMMAND.get(String.class)
+                        .replace("%player%", suspicious)
+                        .replace("%admin%", administrator_user.getUsername()));
 
     }
 


### PR DESCRIPTION
These commits are adding `%admin%` placeholder to `SLOG_COMMAND` on Velocity and BungeeCord, which can be pretty useful if you want to specify specific admin in ban command.